### PR TITLE
refactor(hash): simplify mixers and improve state diffusion; increased speed by 857.11%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ I_FLAGS 		:=  -I. \
 								-Isrc-server/shared/utils/math \
 								-Isrc-server/shared/utils/mixers \
 			
-OPTIMIZE_FLAGS 	:= 	-Os
+OPTIMIZE_FLAGS 	:= 	-O3
 DEBUG_FLAGS 	:= 	-Og -dA -dD -ggdb -Wall -Wextra -Wformat=2 -Wshadow -Wundef
 
 USE_DEBUG		:= 	false

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ I_FLAGS 		:=  -I. \
 								-Isrc-server/shared/utils/math \
 								-Isrc-server/shared/utils/mixers \
 			
-OPTIMIZE_FLAGS 	:= 	-O3
+OPTIMIZE_FLAGS 	:= 	-O3 -march=native -flto
 DEBUG_FLAGS 	:= 	-Og -dA -dD -ggdb -Wall -Wextra -Wformat=2 -Wshadow -Wundef
 
 USE_DEBUG		:= 	false

--- a/src-server/infra/hash/main.c
+++ b/src-server/infra/hash/main.c
@@ -16,6 +16,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
+#include <stdio.h>
 
 bytes_t HashDjb2(bytes_t src) {
     ulong_t hash = 5381;
@@ -146,62 +148,72 @@ void _seedState(int wordLen, uint32_t *state, const scorpionSettings *ctx) {
     }
 }
 
-void _mixStateWithSrc(bytes_t src, uint32_t *state, int wordLen) {
-    for (size_t i = 0; i < src.len; i++) {
+void _mixStateWithSrc(bytes_t src, uint32_t *state, int wordLen, const int *index) {
+    for (int i = 0; i < (int)src.len; i++) {
         // Here we define the currentByte
-        uint32_t currentByte = src.b[i];
-        uint32_t *word = &state[i & (wordLen - 1)];
+
+        uint32_t curByte =  src.b[i % src.len] |
+                            (src.b[(i + 1) % src.len] << 8) |
+                            (src.b[(i + 2) % src.len] << 16) |
+                            (src.b[(i + 3) % src.len] << 24);
+
+        uint32_t secByte =  src.b[(i + 19) % src.len] |
+                            (src.b[(i + 28) % src.len] << 8) |
+                            (src.b[(i + 36) % src.len] << 16) |
+                            (src.b[(i + 11) % src.len] << 24);
+
+        uint32_t word = state[i & (wordLen - 1)];
+
+        flavourmix32(&curByte, 0x6B8FA177);
+        flavourmix32(&secByte, 0x1CFE885B);
 
         // Now we iterate inside the current word
         const struct minimix_src indexes = {
             .src = {
-                currentByte,
-                src.b[(i + 2) % src.len],
-                src.b[(i + 30) % src.len]
+                curByte,
+                secByte,
+                word ^ rotr(curByte & 0x1F, secByte & 0x1F)
             }
         };
 
-        minimix32(indexes, word);
+        minimix32(indexes, &word);
 
         // Now we define [v]alue, that must be based in state and must interact with currentByte
         // The idx (index) is the state's index that we'll modify
-        uint32_t v = fmix32(state[i & (wordLen - 1)]);
-        uint32_t idx = state[i % wordLen] ^ ((v << 9) ^ 0xFFF1FF2F);
+        uint32_t v = fmix32(word) ^ 0x85EBCA6Bu;
+        uint32_t idx = word ^ ((v << 9) ^ 0xDEADBEEF);
 
-        // Modify the state index and next word
-        arxmix32(state, (int*)&idx, (int*)&i, wordLen);
+        uint32_t trdByte =  src.b[(i + 16) % src.len] |
+                            (src.b[(i + 39) % src.len] << 8) |
+                            (src.b[(i + 44) % src.len] << 16) |
+                            (src.b[(i + 4) % src.len] << 24);
+
+        smallmix32(&trdByte);
 
         const struct minimix_src secondIndexes = {
             .src = {
-                src.b[i % src.len],
-                src.b[(i + 16) % src.len],
-                src.b[(i + 39) % src.len]
+                curByte,
+                trdByte,
+                curByte ^ trdByte
             }
         };
 
-        minimix32(secondIndexes, word);
-
-        state[(idx + 78) & (wordLen - 1)] += state[idx & (wordLen - 1)];
-
-        uint32_t x = currentByte ^ state[(idx + 2) & (wordLen - 1)];
-        smallmix32(&x);
-
-        uint32_t spread = currentByte * 0x9E3779B1;
-        flavourmix32(&state[(idx + (88 * i)) & (wordLen - 1)], spread);
+        minimix32(secondIndexes, &word);
+        state[i & (wordLen - 1)] = word;
     }
 }
 
 void _mixState(int wordLen, int miniWordLen, uint32_t *state, const int *index) {
     int i = *index;
 
-    for (int r = 0; r < wordLen; r++)
+    for (int r = 0; r < miniWordLen; r++)
         arraymix32(state, &r, wordLen, &i, miniWordLen);
 }
 
 void _finalizer(int wordLen, uint32_t *state) {
     uint32_t mask = wordLen - 1;
 
-    for (int i = 0; i < wordLen; i++) {
+    for (int i = 0; i < 4; i++) {
         struct minimix_src mixSrc = {
             .src = { 
                 state[(i + 83) & mask],
@@ -218,7 +230,7 @@ void _finalizer(int wordLen, uint32_t *state) {
         minimix16(mixSrc, &a);
         minimix16(mixSrc, &b);
 
-        state[i] = a | b;
+        state[i] = a | ((uint32_t)b << 16);
     }
 }
 
@@ -236,16 +248,17 @@ bytes_t HashScorpionX(bytes_t src) {
     bytes_t out;
     out.len = hashLen;
     out.b = malloc(out.len);
-
     uint32_t *state = _getState(wordLen);
     if (state == NULL)
         return (bytes_t){NULL, 0};
 
     _seedState(wordLen, state, Hash.settings);
-    _mixStateWithSrc(src, state, wordLen);
-
-    for (int i = 0; i < miniWordLen; i++) {
+    for (int i = 0; i < 4; i++)
         _mixState(wordLen, miniWordLen, state, &i);
+
+    mixtwo32(state, &src, wordLen);
+    for (int i = 0; i < miniWordLen; i++) {
+        _mixStateWithSrc(src, state, wordLen, &i);
         multiarxmix32(state, wordLen, &i, src);
     }
 

--- a/src-server/infra/hash/main.c
+++ b/src-server/infra/hash/main.c
@@ -9,15 +9,17 @@
 //      source code for crackme in https://crackmes.one/crackme/6973ebc6d735cd51e7a1aa97
 //
 
-#include "main.h"
+#include "src-server/infra/hash/main.h"
 
 #include "src-server/shared/utils/math/main.h"
 #include "src-server/shared/utils/mixers/main.h"
+#include <inttypes.h>
+#include <iso646.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
-#include <stdio.h>
 
 bytes_t HashDjb2(bytes_t src) {
     ulong_t hash = 5381;
@@ -148,33 +150,27 @@ void _seedState(int wordLen, uint32_t *state, const scorpionSettings *ctx) {
     }
 }
 
-void _mixStateWithSrc(bytes_t src, uint32_t *state, int wordLen, const int *index) {
-    for (int i = 0; i < (int)src.len; i++) {
-        // Here we define the currentByte
+void _mixStateWithSrc(bytes_t src, uint32_t *state, int wordLen) {
+    size_t srcLen = src.len;
+    for (int i = 0; i < (int)srcLen; i++) {
+        uint32_t curByte = src.b[wrap_idx(i, srcLen)] |
+                           (src.b[wrap_idx(i + 1, srcLen)] << 8) |
+                           (src.b[wrap_idx(i + 2, srcLen)] << 16) |
+                           (src.b[wrap_idx(i + 3, srcLen)] << 24);
 
-        uint32_t curByte =  src.b[i % src.len] |
-                            (src.b[(i + 1) % src.len] << 8) |
-                            (src.b[(i + 2) % src.len] << 16) |
-                            (src.b[(i + 3) % src.len] << 24);
-
-        uint32_t secByte =  src.b[(i + 19) % src.len] |
-                            (src.b[(i + 28) % src.len] << 8) |
-                            (src.b[(i + 36) % src.len] << 16) |
-                            (src.b[(i + 11) % src.len] << 24);
+        uint32_t secByte = src.b[wrap_idx(i + 19, srcLen)] |
+                           (src.b[wrap_idx(i + 28, srcLen)] << 8) |
+                           (src.b[wrap_idx(i + 36, srcLen)] << 16) |
+                           (src.b[wrap_idx(i + 11, srcLen)] << 24);
 
         uint32_t word = state[i & (wordLen - 1)];
 
-        flavourmix32(&curByte, 0x6B8FA177);
-        flavourmix32(&secByte, 0x1CFE885B);
+        curByte = fmix32(curByte);
+        secByte = fmix32(secByte);
 
         // Now we iterate inside the current word
         const struct minimix_src indexes = {
-            .src = {
-                curByte,
-                secByte,
-                word ^ rotr(curByte & 0x1F, secByte & 0x1F)
-            }
-        };
+            .src = {curByte, secByte, word ^ rotr(curByte, secByte & 0x1F)}};
 
         minimix32(indexes, &word);
 
@@ -183,27 +179,23 @@ void _mixStateWithSrc(bytes_t src, uint32_t *state, int wordLen, const int *inde
         uint32_t v = fmix32(word) ^ 0x85EBCA6Bu;
         uint32_t idx = word ^ ((v << 9) ^ 0xDEADBEEF);
 
-        uint32_t trdByte =  src.b[(i + 16) % src.len] |
-                            (src.b[(i + 39) % src.len] << 8) |
-                            (src.b[(i + 44) % src.len] << 16) |
-                            (src.b[(i + 4) % src.len] << 24);
+        uint32_t trdByte = src.b[wrap_idx(i + 16, srcLen)] |
+                           (src.b[wrap_idx(i + 39, srcLen)] << 8) |
+                           (src.b[wrap_idx(i + 44, srcLen)] << 16) |
+                           (src.b[wrap_idx(i + 4, srcLen)] << 24);
 
-        smallmix32(&trdByte);
+        trdByte = fmix32(trdByte);
 
         const struct minimix_src secondIndexes = {
-            .src = {
-                curByte,
-                trdByte,
-                curByte ^ trdByte
-            }
-        };
+            .src = {curByte, trdByte, curByte ^ trdByte}};
 
         minimix32(secondIndexes, &word);
         state[i & (wordLen - 1)] = word;
     }
 }
 
-void _mixState(int wordLen, int miniWordLen, uint32_t *state, const int *index) {
+void _mixState(int wordLen, int miniWordLen, uint32_t *state,
+               const int *index) {
     int i = *index;
 
     for (int r = 0; r < miniWordLen; r++)
@@ -213,15 +205,12 @@ void _mixState(int wordLen, int miniWordLen, uint32_t *state, const int *index) 
 void _finalizer(int wordLen, uint32_t *state) {
     uint32_t mask = wordLen - 1;
 
+    // Self mixing
     for (int i = 0; i < 4; i++) {
-        struct minimix_src mixSrc = {
-            .src = { 
-                state[(i + 83) & mask],
-                state[(i + 17) & mask],
-                state[(i + 27) & mask]
-            }
-        };
-        
+        struct minimix_src mixSrc = {.src = {state[(i + 83) & mask],
+                                             state[(i + 17) & mask],
+                                             state[(i + 27) & mask]}};
+
         minimix32(mixSrc, &state[i]);
 
         uint16_t a = state[i] & 0xFFFF;
@@ -231,6 +220,28 @@ void _finalizer(int wordLen, uint32_t *state) {
         minimix16(mixSrc, &b);
 
         state[i] = a | ((uint32_t)b << 16);
+    }
+
+    // Cross-lane mixing
+    for (int i = 0; i < wordLen; i++) {
+        uint32_t old = state[i & mask];
+
+        state[i & mask] ^= state[(i + 10) & mask];
+        state[i & mask] += state[(i + 29) & mask];
+        state[i & mask] ^= rotl(state[(i + 38) & mask], 11);
+
+        state[i & mask] ^= old;
+    }
+
+    for (int i = 0; i < wordLen; i++) {
+        uint32_t old = state[i & mask];
+
+        state[i & mask] *= 0x85F7B117;
+        state[i & mask] ^= rotl(state[i & mask], 16);
+        state[i & mask] *= 0x9FD223F;
+        state[i & mask] ^= rotr(state[i & mask], 11);
+
+        state[i & mask] ^= old;
     }
 }
 
@@ -257,198 +268,17 @@ bytes_t HashScorpionX(bytes_t src) {
         _mixState(wordLen, miniWordLen, state, &i);
 
     mixtwo32(state, &src, wordLen);
-    for (int i = 0; i < miniWordLen; i++) {
-        _mixStateWithSrc(src, state, wordLen, &i);
+    _mixStateWithSrc(src, state, wordLen);
+
+    for (int i = 0; i < 4; i++) {
         multiarxmix32(state, wordLen, &i, src);
     }
 
-    for (int i = 0; i < (miniWordLen * 2); i++)
+    for (int i = 0; i < miniWordLen; i++)
         dependency32(wordLen, state, &i);
 
-    _finalizer(wordLen, state);
-
-//        // Cross words mixing
-//        for (int cwm = 0; cwm < wordLen; cwm++) {
-//            uint32_t old = state[cwm];
-//            for (int m = 0; m < miniWordLen; m++) {
-//                uint32_t word = state[i];
-//
-//                uint8_t mw0 = word & 0xFF;
-//                uint8_t mw1 = (word >> 8) & 0xFF;
-//                uint8_t mw2 = (word >> 16) & 0xFF;
-//                uint8_t mw3 = (word >> 24) & 0xFF;
-//
-//                mw0 = rotl8(mw0, 20);
-//                mw0 ^= (mw0 >> 4);
-//                mw0 *= seed_helper(0xBAEF2124, seed, shiftSeed);
-//                mw0 ^= rotr8(state[(i + 37) & (wordLen - 1)] & 0xFF, 2);
-//                mw0 ^= (mw0 << 5) | (mw0 >> 7);
-//
-//                uint8_t mw0x =
-//                    (mw0 << 7) ^
-//                    (mw0 * (mw0 ^ seed_helper(0x2BDA, seed, shiftSeed)));
-//                for (int it = 0; it < 15; it++) {
-//                    uint8_t oldX = mw0x;
-//
-//                    uint8_t x =
-//                        (mw0x << ((mw0 ^ seed_helper(0x6FAA, seed, shiftSeed)) &
-//                                  8)) ^
-//                        mw0;
-//                    x ^= x >> 6;
-//                    x *= 0x2C6D;
-//                    x ^= x >> 7;
-//                    x *= 0x2979;
-//                    x ^= x >> 4;
-//
-//                    mw0x = x;
-//                    mw0x ^= oldX;
-//                }
-//
-//                mw1 = rotr8(mw1, 5);
-//                mw1 ^= (mw1 << 6) ^ rotl8(mw1, 7);
-//                mw1 += 1;
-//                mw1 ^= (mw1 ^ seed_helper(0x0539, seed, shiftSeed - 1))
-//                       << ((mw1 - 1) & 8);
-//
-//                uint8_t mw1x =
-//                    (((mw1 * 200202) & sizeof(uint8_t)) ^ (mw1 - 2)) << rotl8(
-//                        mw1, (mw1 ^ seed_helper(0x9998, seed, shiftSeed)) & 8);
-//                for (int it = 0; it < 15; it++) {
-//                    uint8_t oldX = mw1x;
-//                    uint8_t x = (mw1x * rotl8(mw1x, 3)) ^ (mw1x << 28);
-//
-//                    uint32_t a = x;
-//                    uint32_t b = x >> 6;
-//                    uint32_t c = x << 2;
-//
-//                    a += b;
-//                    c ^= a;
-//                    c = rotl8(c, 6);
-//
-//                    b += c;
-//                    a ^= b;
-//                    a = rotl8(a, 2);
-//
-//                    x = a;
-//                    x ^= b << 5;
-//                    x ^= c >> 4;
-//
-//                    x ^= oldX;
-//                    mw1x = x + 1;
-//                }
-//
-//                mw2 = rotr8(mw2, mw3 & 8);
-//                mw2 ^= (mw3 << 6) ^ rotl8(mw2, 7);
-//                mw3 ^= mw2 >> (mw2 ^ 0xBF8F) & 8;
-//                mw2 ^= (mw3 << ((mw2 >> 4) & 8));
-//                mw3 = rotl8(mw2, 27);
-//                mw3 ^= mw2 << 7;
-//                mw2 ^= mw3 >> 5;
-//
-//                uint8_t mw5x =
-//                    (mw2 *
-//                     (mw3 >> (mw2 ^ seed_helper(0x1C4D, seed << 9, shiftSeed)) &
-//                      8)) ^
-//                    (mw2 << (mw3 & 8));
-//                for (int it = 0; it < 30; it++) {
-//                    uint8_t oldX = mw5x;
-//                    uint8_t x =
-//                        (mw5x ^ ((mw5x << 1) ^ ((mw5x << 2) ^ (mw5x << 3)))) ^
-//                        (mw5x << 4);
-//
-//                    uint32_t j = (it * 5 + 1);
-//                    uint32_t k = (it * 3 + 1);
-//
-//                    uint32_t t = x;
-//                    x = (x ^ (x * j)) >> (x & 8);
-//                    x = (x ^ (x * (it * 3 + 1))) << (((it * 5 + 1) * x) & 8);
-//                    x = rotl8(x, (it * 3 + 1));
-//                    x ^= t << 6;
-//                    x ^= t ^ (k >> 7);
-//
-//                    mw5x = x;
-//                    mw5x ^= oldX;
-//                }
-//
-//                uint8_t mw3x = rotr8(mw5x, mw2 & 7);
-//                uint8_t mw2x = rotl8(mw5x, mw3 & 7);
-//
-//                state[i] = mw0x | (mw1x << 8) | (mw2x << 16) | (mw3x << 24);
-//
-//                state[i] += mw0x;
-//                state[(i + 22) & (wordLen - 1)] *= mw1x;
-//                state[i] = rotl(state[i], mw2x & 0x1F);
-//                state[i] = rotr(state[i], mw3x & 0x1F);
-//
-//                state[cwm] ^= state[i];
-//            }
-//
-//            state[(cwm + 3) & (wordLen - 1)] ^= old;
-//            state[cwm] =
-//                rotr(state[cwm], state[(cwm + 1) & (wordLen - 1)] & 0x1F);
-//            state[(cwm + 80) & (wordLen - 1)] ^= state[cwm];
-//        }
-//
-//        // Cross-lane mixing
-//        for (int clm = 0; clm < wordLen; clm++) {
-//            uint32_t old = state[clm];
-//
-//            state[clm] ^= state[(clm + 7) & mask];
-//            state[clm] += state[(clm + 13) & mask];
-//            state[clm] ^= rotl(state[(clm + 37) & mask], 11);
-//
-//            state[clm] ^= old;
-//        }
-//
-//        // Multiplicative Scrambling
-//        for (int ms = 0; ms < wordLen; ms++) {
-//            uint32_t old = state[ms];
-//
-//            state[ms] *= 0x9E3779B1;
-//            state[ms] ^= state[ms] >> 16;
-//            state[ms] *= 0x85EBCA6B;
-//            state[ms] ^= rotl(state[ms], 11);
-//
-//            state[ms] ^= old;
-//        }
-//
-//        // Bit avalanche injection
-//        for (int bai = 0; bai < wordLen; bai++) {
-//            uint32_t old = state[bai];
-//
-//            uint32_t x = state[bai];
-//
-//            x ^= x >> 15;
-//            x *= 0x2C1B3C6D;
-//            x ^= x >> 12;
-//            x *= 0x297A2D39;
-//            x ^= x >> 15;
-//
-//            state[bai] = x;
-//            state[bai] ^= old;
-//        }
-//
-//        // Global Diffusion
-//        for (int gd = 0; gd < wordLen; gd++) {
-//            state[gd] ^= state[(gd + 7) & (wordLen - 1)];
-//            state[gd] ^= state[(gd + 13) & (wordLen - 1)];
-//            state[gd] ^= state[(gd + 37) & (wordLen - 1)];
-//        }
-//
-//        // Lane shuffle
-//        for (int ls = 0; ls < wordLen; ls++) {
-//            uint32_t old = state[ls];
-//
-//            uint32_t j = (ls * 5 + 1) & mask;
-//            uint32_t k = (ls * 3 + 1) & mask;
-//
-//            uint32_t t = state[ls];
-//            state[ls] = state[j];
-//            state[j] = state[k];
-//            state[k] = t;
-//
-//            state[ls] ^= old;
-//        }
+    for (int i = 0; i < 4; i++)
+        _finalizer(wordLen, state);
 
     // Last block of iteration, this will create the output
     for (int i = 0; i < wordLen; i++) {

--- a/src-server/infra/hash/main.c
+++ b/src-server/infra/hash/main.c
@@ -177,7 +177,6 @@ void _mixStateWithSrc(bytes_t src, uint32_t *state, int wordLen) {
         // Now we define [v]alue, that must be based in state and must interact with currentByte
         // The idx (index) is the state's index that we'll modify
         uint32_t v = fmix32(word) ^ 0x85EBCA6Bu;
-        uint32_t idx = word ^ ((v << 9) ^ 0xDEADBEEF);
 
         uint32_t trdByte = src.b[wrap_idx(i + 16, srcLen)] |
                            (src.b[wrap_idx(i + 39, srcLen)] << 8) |
@@ -199,7 +198,7 @@ void _mixState(int wordLen, int miniWordLen, uint32_t *state,
     int i = *index;
 
     for (int r = 0; r < miniWordLen; r++)
-        arraymix32(state, &r, wordLen, &i, miniWordLen);
+        arraymix32(state, &r, wordLen, &i);
 }
 
 void _finalizer(int wordLen, uint32_t *state) {

--- a/src-server/infra/hash/main.c
+++ b/src-server/infra/hash/main.c
@@ -174,10 +174,6 @@ void _mixStateWithSrc(bytes_t src, uint32_t *state, int wordLen) {
 
         minimix32(indexes, &word);
 
-        // Now we define [v]alue, that must be based in state and must interact with currentByte
-        // The idx (index) is the state's index that we'll modify
-        uint32_t v = fmix32(word) ^ 0x85EBCA6Bu;
-
         uint32_t trdByte = src.b[wrap_idx(i + 16, srcLen)] |
                            (src.b[wrap_idx(i + 39, srcLen)] << 8) |
                            (src.b[wrap_idx(i + 44, srcLen)] << 16) |

--- a/src-server/infra/hash/main.c
+++ b/src-server/infra/hash/main.c
@@ -267,42 +267,6 @@ bytes_t HashScorpionX(bytes_t src) {
 
     _finalizer(wordLen, state);
 
-    // This block will be implemented in _finalizer later
-    /*
-     * Sixth block of iteration, this is a finalizer for the state
-     *
-     * The goal of this is to destroy internal correlations by mixing some well-tested algorithms/methods in the My custom One
-     *
-     */
-//    for (int i = 0; i < 2; i++) {
-//        uint32_t mask = wordLen - 1;
-//
-//        // Mix miniWords From Hash Edge
-//            // Already in _finalizer
-//
-//        // ARX
-//        for (int arx = 0; arx < wordLen; arx++) {
-//            uint32_t old = state[arx];
-//
-//            uint32_t a = state[arx];
-//            uint32_t b = state[(arx + 1) & mask];
-//            uint32_t c = state[(arx + 2) & mask];
-//
-//            a += b;
-//            c ^= a;
-//            c = rotl(c, 16);
-//
-//            b += c;
-//            a ^= b;
-//            a = rotl(a, 12);
-//
-//            state[arx] = a;
-//            state[(arx + 1) & mask] = b;
-//            state[(arx + 2) & mask] = c;
-//
-//            state[arx] ^= old;
-//        }
-//
 //        // Cross words mixing
 //        for (int cwm = 0; cwm < wordLen; cwm++) {
 //            uint32_t old = state[cwm];
@@ -448,41 +412,6 @@ bytes_t HashScorpionX(bytes_t src) {
 //            state[ms] ^= old;
 //        }
 //
-//        // Word self-mixing
-//        for (int wsm = 0; wsm < wordLen; wsm++) {
-//            for (int m = 0; m < miniWordLen; m++) {
-//                uint32_t old = state[wsm];
-//                uint32_t word = state[wsm];
-//
-//                word ^= word << 13;
-//                word ^= word >> 17;
-//                word -= word << 23;
-//                word = rotl(word, 16);
-//                word = rotr(word, 22);
-//
-//                uint32_t curWord = word;
-//                word = rotr(word, ((word << 29) & m) ^
-//                                      ((curWord >> 11) | (word << (m & 0x1F))));
-//                word ^=
-//                    rotl(curWord, ((word << 29) & m) ^
-//                                      ((curWord >> 11) | (word << (m & 0x1F))));
-//                word ^= (curWord << (word & 0x1F));
-//
-//                state[wsm] = word;
-//                state[wsm] ^= old;
-//            }
-//        }
-//
-//        // Butterfly mixing
-//        for (int bm = 0; bm < wordLen; bm++) {
-//            uint32_t old = state[bm];
-//
-//            state[bm] ^= state[(wordLen - bm - 1) & mask];
-//            state[(bm + 1) & mask] += state[(wordLen / 2 + bm + 1) & mask];
-//
-//            state[bm] ^= old;
-//        }
-//
 //        // Bit avalanche injection
 //        for (int bai = 0; bai < wordLen; bai++) {
 //            uint32_t old = state[bai];
@@ -520,17 +449,6 @@ bytes_t HashScorpionX(bytes_t src) {
 //
 //            state[ls] ^= old;
 //        }
-//
-//        // Non-linear mix
-//        for (int nlm = 0; nlm < wordLen; nlm++) {
-//            uint32_t old = state[nlm];
-//
-//            state[nlm] ^= (state[nlm] << 7) & (state[(nlm + 3) & mask]);
-//            state[nlm] += (state[(nlm + 1) & mask] ^ ~state[(nlm + 2) & mask]);
-//
-//            state[nlm] ^= old;
-//        }
-//    }
 
     // Last block of iteration, this will create the output
     for (int i = 0; i < wordLen; i++) {

--- a/src-server/shared/utils/math/main.h
+++ b/src-server/shared/utils/math/main.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdlib.h>
 
 static inline uint32_t rotl(const uint32_t x, int r) {
     r &= 0x1F;
@@ -35,4 +36,11 @@ static inline uint16_t rotl16(const uint16_t x, uint16_t n) {
 static inline uint16_t rotr16(const uint16_t x, uint16_t n) {
     n &= 0x10;
     return (x >> (n & 15)) | (x << ((16 - n) & 15));
+}
+
+static inline size_t wrap_idx(size_t idx, size_t len) {
+    while (idx >= len)
+        idx -= len;
+
+    return idx;
 }

--- a/src-server/shared/utils/mixers/main.c
+++ b/src-server/shared/utils/mixers/main.c
@@ -16,18 +16,19 @@ void arxmix8(uint8_t *word, uint32_t srcWord) {
 
     uint8_t old = *word;
 
-    *word += rotl8(msw0, *word);
+    *word ^= rotl8(msw0, *word);
     *word ^= rotr8(msw1, *word);
-    *word *= msw2 ^ rotl8(*word, msw0);
+    *word += msw2 ^ rotl8(*word, msw0);
     *word ^= msw3 * rotr8(msw1, *word + 1);
     *word *= rotl8(*word, msw0);
 
-    *word ^= rotr8(*word, old);
+    *word ^= old;
 }
 
 void minimix32(const struct minimix_src src, uint32_t *pword) {
     uint32_t curByte = src.src[0];
     uint32_t word = *pword;
+    word *= 0x39D652DB;
 
     uint8_t mw0 = word & 0xFF;
     uint8_t mw1 = (word >> 8) & 0xFF;
@@ -35,9 +36,9 @@ void minimix32(const struct minimix_src src, uint32_t *pword) {
     uint8_t mw3 = (word >> 24) & 0xFF;
 
     mw0 ^= rotl8(src.src[1], 3) + mw2;
-    mw1 ^= rotr8(curByte, 5) + src.src[2];
+    mw1 *= rotr8(curByte, src.src[2] & 31);
     mw2 ^= mw0 * (curByte & 0xFF);
-    mw3 ^= mw1 ^ 0xC3;
+    mw3 += mw1 ^ 0xC3;
 
     arxmix8(&mw0, src.src[1]);
     arxmix8(&mw1, src.src[0]);
@@ -69,7 +70,7 @@ void minimix16(const struct minimix_src src, uint16_t *pword) {
     arxmix8(&mnw0, src.src[2]);
     arxmix8(&mnw1, word);
 
-    *pword = summarize16(mw0 | (mw1 << 8) | (mnw0 << 16) | (mnw1 << 24));
+    *pword = summarize16(mw0 | (uint32_t)(mw1 << 8) | (uint32_t)(mnw0 << 16) | (uint32_t)(mnw1 << 24));
 
 }
 
@@ -79,20 +80,21 @@ void arxmix32(uint32_t *state, const int *_r, const int *_i, int wordLen) {
 
     state[r & (wordLen - 1)] += state[(r + 82) & (wordLen - 1)];
     state[r & (wordLen - 1)] ^= state[(i + 19) & (wordLen - 1)];
-    state[r & (wordLen - 1)] = rotr(state[r & (wordLen - 1)], state[(i + 83) & (wordLen - 1)] & 31);
-    state[r & (wordLen - 1)] ^= state[(r + 52) & (wordLen - 1)] ^ rotr(state[(i + 24) & (wordLen - 1)], state[(r + 31) & (wordLen - 1)]);
+    state[r & (wordLen - 1)] *= rotr((state[r & (wordLen - 1)]), (state[(i + 83) & (wordLen - 1)] & 31));
+    state[r & (wordLen - 1)] ^= state[(r + 52) & (wordLen - 1)] ^ rotr((state[(i + 24) & (wordLen - 1)]), (state[(r + 31) & (wordLen - 1)] & 31));
 
-    state[r & (wordLen - 1)] += state[(i + r + 7) & (wordLen - 1)] & 0xF;
+    state[r & (wordLen - 1)] += state[(i + r + 7) & (wordLen - 1)];
     state[r & (wordLen - 1)] *= 0x9E3779B1;
     state[r & (wordLen - 1)] ^= state[r & (wordLen - 1)] >> 16;
 }
 
 void arraymix32(uint32_t *state, const int *index, int wordLen, const int *_i, int miniWordLen) {
     int i = *_i;
+    uint32_t mask = wordLen - 1;
 
-    state[*index] ^= state[(*index + i + 1) & (wordLen - 1)];
-    state[*index] = rotl(state[*index], state[(*index + i + 1) & (miniWordLen - 1)] & 31);
-    state[*index] = rotl(state[*index], 16);
+    state[*index & mask] ^= state[(*index + i + 1) & mask];
+    state[*index & mask] *= rotl(state[*index & mask], state[(*index + i + 1) & mask] & 31);
+    state[*index & mask] ^= rotl(state[*index & mask], 16);
 
     const struct minimix_src indexes = {
         .src = {
@@ -104,46 +106,41 @@ void arraymix32(uint32_t *state, const int *index, int wordLen, const int *_i, i
 
     minimix32(indexes, &state[*index]);
 
-    state[*index] ^= 0x838383FF;
-    state[*index] += state[(*index + 44) & (wordLen - 1)];
-    state[*index] ^= state[i & (wordLen - 1)] * 0x9E37D9BF;
-    state[*index] += 1;
+    state[*index & mask] ^= 0x838383FF;
+    state[*index & mask] += state[(*index + 44) & mask];
+    state[*index & mask] ^= state[i & mask] * 0x9E37D9BF;
+    state[*index & mask] += 1;
 }
 
 void multiarxmix32(uint32_t *state, int wordLen, const int *_i, bytes_t src) {
     int i = *_i;
 
-    for (int r = 0; r < wordLen; r++) {
+    for (int r = 0; r < 4; r++) {
         uint32_t currentByte = src.b[i % src.len] ^ 0xAB808DF1;
-        uint32_t mix = currentByte ^ rotl(currentByte, src.b[(i + 1) % src.len]);
+        uint32_t mix = currentByte ^ rotl(src.b[(i + 1) % src.len], 0xBEEA5123);
 
-        flavourmix32(&state[r & (wordLen - 1)], mix);
+        flavourmix32(&state[r & (wordLen - 1)], currentByte ^ mix);
         arxmix32(state, &r, &i, wordLen);
     }
 }
 
 void dependency32(int wordLen, uint32_t *state, const int *index) {
-    for (int r = 0; r < wordLen; r++)
+    for (int r = 0; r < 4; r++)
         arxmix32(state, &r, index, wordLen);
 
     // This sub-block will ensure that high bits influence low bits
-    for (int ii = 0; ii < wordLen; ii++)
+    for (int ii = 0; ii < 4; ii++)
         state[ii] ^= state[(ii + 1) & (wordLen - 1)] >> 1;
 }
 
 void smallmix32(uint32_t *word) {
     uint32_t w = *word;
 
-    for (int i = 0; i < 32; i++) {
+    for (int i = 0; i < 8; i++) {
+        w *= 0x140329DD ^ (i | 1);
         w ^= 0x912125FF;
-        w *= rotl(w, 0x0870518D);
-        w ^= rotr(w, *word);
-
-        w *= w ^ rotl(w, 0xDEADBEEF);
         w ^= w * rotr(w, 0x13371337);
-        w *= w << (rotr(w, 0x0539) & 0x1F);
 
-        w ^= *word;
     }
 
     *word = w;
@@ -152,16 +149,11 @@ void smallmix32(uint32_t *word) {
 void smallmix16(uint16_t *word) {
     uint16_t w = *word;
 
-    for (int i = 0; i < 16; i++) {
+    for (int i = 0; i < 4; i++) {
+        w *= 0x98430E0D ^ (i | 1);
         w ^= 0x1337;
-        w *= rotr16(w, 0xDEAD);
-        w ^= rotl16(w, 0xBEEF);
-
-        w *= w ^ rotl16(w, 0x0539);
         w ^= w * rotr16(w, 0xF00F);
-        w *= w >> (rotl16(w, 0xABCD) & 0xF);
 
-        w ^= *word;
     }
 
     *word = w;
@@ -170,21 +162,11 @@ void smallmix16(uint16_t *word) {
 void flavourmix32(uint32_t *word, uint32_t flavour) {
     uint32_t w = *word;
 
-    for (int i = 0; i < 32; i++) {
-        smallmix32(&w);
-        smallmix32(&flavour);
-
+    for (int i = 0; i < 8; i++) {
         w ^= flavour;
-        w *= rotl(flavour, w);
-        w ^= rotr(w, flavour);
-
-        flavour ^= *word;
-
-        w *= w ^ rotl(flavour, 0xDEADBEEF);
-        w ^= w * rotr(flavour, w);
-        w *= w << (rotl(flavour, 0x13371337) & 0x1F);
-
-        w ^= *word;
+        w *= 0x3008B987;
+        w = rotr(w, 11);
+        w ^= rotl(flavour, 7);
     }
 
     *word = w;
@@ -193,21 +175,11 @@ void flavourmix32(uint32_t *word, uint32_t flavour) {
 void flavourmix16(uint16_t *word, uint16_t flavour) {
     uint16_t w = *word;
 
-    for (int i = 0; i < 16; i++) {
-        smallmix16(&w);
-        smallmix16(&flavour);
-
+    for (int i = 0; i < 4; i++) {
         w ^= flavour;
-        w *= rotr16(flavour, w);
-        w ^= rotl16(w, flavour);
-
-        flavour ^= *word;
-
-        w *= w ^ rotr16(flavour, 0xDEAD);
-        w ^= w * rotl16(flavour, w);
-        w *= w << (rotr16(flavour, 0x1337) & 0xF);
-
-        w ^= *word;
+        w *= 0xCEE1;
+        w = rotl16(w, 3);
+        w ^= rotr16(flavour, 15);
     }
 
     *word = w;
@@ -247,4 +219,41 @@ uint16_t summarize16(uint32_t word) {
     }
 
     return out;
+}
+
+void mixtwo32(uint32_t *state, bytes_t *src, int wordLen) {
+    uint32_t mask = wordLen - 1;
+    for (int i = 0; i < 8; i++) {
+        const struct minimix_src stateMinimixSrc = {
+            .src = {
+                state[i & mask],
+                state[(i + 1) & mask],
+                state[(i + 50) & mask]
+            }
+        };
+
+        const struct minimix_src srcMinimixSrc = {
+            .src = {
+                src->b[i % src->len],
+                src->b[(i + 2) % src->len],
+                src->b[(i + 27) % src->len]
+            }
+        };
+
+        minimix32(srcMinimixSrc, &state[(i + 1) & mask]);
+
+        uint32_t curByte =  src->b[i % src->len] |
+                            (src->b[(i + 1) % src->len] << 8) |
+                            (src->b[(i + 2) % src->len] << 16) |
+                            (src->b[(i + 3) % src->len] << 24);
+
+        minimix32(stateMinimixSrc, &curByte);
+        uint16_t srcA = curByte & 0xFFFF;
+        uint16_t srcB = (curByte >> 16) & 0xFFFF;
+
+        minimix16(stateMinimixSrc, &srcA);
+        minimix16(stateMinimixSrc, &srcB);
+
+        state[(i + 3) & mask] = srcA | ((uint32_t)srcB << 16);
+    }
 }

--- a/src-server/shared/utils/mixers/main.c
+++ b/src-server/shared/utils/mixers/main.c
@@ -4,75 +4,9 @@
 //
 
 #include "src-server/shared/utils/mixers/main.h"
-#include "src-server/shared/utils/math/main.h"
 #include "src-server/shared/types/main.h"
+#include "src-server/shared/utils/math/main.h"
 #include <stdint.h>
-
-void arxmix8(uint8_t *word, uint32_t srcWord) {
-    uint8_t msw0 = srcWord & 0xFF;
-    uint8_t msw1 = (srcWord >> 8) & 0xFF;
-    uint8_t msw2 = (srcWord >> 16) & 0xFF;
-    uint8_t msw3 = (srcWord >> 24) & 0xFF;
-
-    uint8_t old = *word;
-
-    *word ^= rotl8(msw0, *word);
-    *word ^= rotr8(msw1, *word);
-    *word += msw2 ^ rotl8(*word, msw0);
-    *word ^= msw3 * rotr8(msw1, *word + 1);
-    *word *= rotl8(*word, msw0);
-
-    *word ^= old;
-}
-
-void minimix32(const struct minimix_src src, uint32_t *pword) {
-    uint32_t curByte = src.src[0];
-    uint32_t word = *pword;
-    word *= 0x39D652DB;
-
-    uint8_t mw0 = word & 0xFF;
-    uint8_t mw1 = (word >> 8) & 0xFF;
-    uint8_t mw2 = (word >> 16) & 0xFF;
-    uint8_t mw3 = (word >> 24) & 0xFF;
-
-    mw0 ^= rotl8(src.src[1], 3) + mw2;
-    mw1 *= rotr8(curByte, src.src[2] & 31);
-    mw2 ^= mw0 * (curByte & 0xFF);
-    mw3 += mw1 ^ 0xC3;
-
-    arxmix8(&mw0, src.src[1]);
-    arxmix8(&mw1, src.src[0]);
-    arxmix8(&mw2, src.src[2]);
-    arxmix8(&mw3, word);
-
-    *pword = mw0 | (mw1 << 8) | (mw2 << 16) | (mw3 << 24);
-}
-
-void minimix16(const struct minimix_src src, uint16_t *pword) {
-    uint32_t curByte = src.src[0];
-    uint16_t word = *pword;
-
-    uint16_t nWord = rotl16(src.src[1], src.src[2]);
-    flavourmix16(&nWord, 0x9FB6);
-
-    uint8_t mw0 = word & 0xFF;
-    uint8_t mw1 = (word >> 8) & 0xFF;
-    uint8_t mnw0 = nWord & 0xFF;
-    uint8_t mnw1 = (nWord >> 8) & 0xFF;
-
-    mw0 ^= rotr8(src.src[1], 4) + mnw1;
-    mw1 ^= rotl8(curByte, 3) + src.src[2];
-    mnw0 ^= mw0 * (curByte & 0xFF);
-    mnw1 ^= mw1 ^ 0xBB;
-
-    arxmix8(&mw0, src.src[1]);
-    arxmix8(&mw1, src.src[0]);
-    arxmix8(&mnw0, src.src[2]);
-    arxmix8(&mnw1, word);
-
-    *pword = summarize16(mw0 | (uint32_t)(mw1 << 8) | (uint32_t)(mnw0 << 16) | (uint32_t)(mnw1 << 24));
-
-}
 
 void arxmix32(uint32_t *state, const int *_r, const int *_i, int wordLen) {
     int r = *_r;
@@ -80,29 +14,31 @@ void arxmix32(uint32_t *state, const int *_r, const int *_i, int wordLen) {
 
     state[r & (wordLen - 1)] += state[(r + 82) & (wordLen - 1)];
     state[r & (wordLen - 1)] ^= state[(i + 19) & (wordLen - 1)];
-    state[r & (wordLen - 1)] *= rotr((state[r & (wordLen - 1)]), (state[(i + 83) & (wordLen - 1)] & 31));
-    state[r & (wordLen - 1)] ^= state[(r + 52) & (wordLen - 1)] ^ rotr((state[(i + 24) & (wordLen - 1)]), (state[(r + 31) & (wordLen - 1)] & 31));
+    state[r & (wordLen - 1)] *= rotr((state[r & (wordLen - 1)]),
+                                     (state[(i + 83) & (wordLen - 1)] & 31));
+    state[r & (wordLen - 1)] ^= state[(r + 52) & (wordLen - 1)] ^
+                                rotr((state[(i + 24) & (wordLen - 1)]),
+                                     (state[(r + 31) & (wordLen - 1)] & 31));
 
     state[r & (wordLen - 1)] += state[(i + r + 7) & (wordLen - 1)];
     state[r & (wordLen - 1)] *= 0x9E3779B1;
     state[r & (wordLen - 1)] ^= state[r & (wordLen - 1)] >> 16;
 }
 
-void arraymix32(uint32_t *state, const int *index, int wordLen, const int *_i, int miniWordLen) {
+void arraymix32(uint32_t *state, const int *index, int wordLen, const int *_i,
+                int miniWordLen) {
     int i = *_i;
     uint32_t mask = wordLen - 1;
 
     state[*index & mask] ^= state[(*index + i + 1) & mask];
-    state[*index & mask] *= rotl(state[*index & mask], state[(*index + i + 1) & mask] & 31);
+    state[*index & mask] *=
+        rotl(state[*index & mask], state[(*index + i + 1) & mask] & 31);
     state[*index & mask] ^= rotl(state[*index & mask], 16);
 
     const struct minimix_src indexes = {
-        .src = {
-            state[(*index + i + 2) & (wordLen - 1)],
-            state[(*index + i + 10) & (wordLen - 1)],
-            state[(*index + i + 21) & (wordLen - 1)]
-        }
-    };
+        .src = {state[(*index + i + 2) & (wordLen - 1)],
+                state[(*index + i + 10) & (wordLen - 1)],
+                state[(*index + i + 21) & (wordLen - 1)]}};
 
     minimix32(indexes, &state[*index]);
 
@@ -136,11 +72,10 @@ void dependency32(int wordLen, uint32_t *state, const int *index) {
 void smallmix32(uint32_t *word) {
     uint32_t w = *word;
 
-    for (int i = 0; i < 8; i++) {
+    for (int i = 0; i < 4; i++) {
         w *= 0x140329DD ^ (i | 1);
         w ^= 0x912125FF;
         w ^= w * rotr(w, 0x13371337);
-
     }
 
     *word = w;
@@ -153,7 +88,6 @@ void smallmix16(uint16_t *word) {
         w *= 0x98430E0D ^ (i | 1);
         w ^= 0x1337;
         w ^= w * rotr16(w, 0xF00F);
-
     }
 
     *word = w;
@@ -162,7 +96,7 @@ void smallmix16(uint16_t *word) {
 void flavourmix32(uint32_t *word, uint32_t flavour) {
     uint32_t w = *word;
 
-    for (int i = 0; i < 8; i++) {
+    for (int i = 0; i < 4; i++) {
         w ^= flavour;
         w *= 0x3008B987;
         w = rotr(w, 11);
@@ -185,37 +119,19 @@ void flavourmix16(uint16_t *word, uint16_t flavour) {
     *word = w;
 };
 
-uint16_t summarize16(uint32_t word) {
+inline uint16_t summarize16(uint32_t word) {
+    smallmix32(&word);
+
     uint16_t a = word & 0xFFFF;
     uint16_t b = (word >> 16) & 0xFFFF;
 
-    smallmix16(&a);
-    smallmix16(&b);
-
-    uint8_t a0 = a & 0xFF;
-    uint8_t a1 = (a >> 8) & 0xFF;
-    uint8_t b0 = b & 0xFF;
-    uint8_t b1 = (b >> 8) & 0xFF;
-
-    arxmix8(&a0, word);
-    arxmix8(&a1, word);
-    arxmix8(&b0, word);
-    arxmix8(&b1, word);
-
     uint16_t out = 0;
-
     for (int i = 7; i >= 1; i -= 2) {
         out <<= 1;
-        out |= (a0 >> i) & 1;
+        out |= (a >> i) & 1;
 
         out <<= 1;
-        out |= (b1 >> i) & 1;
-
-        out <<= 1;
-        out |= (a1 >> i) & 1;
-
-        out <<= 1;
-        out |= (b0 >> i) & 1;
+        out |= (b >> (15 - i)) & 1;
     }
 
     return out;
@@ -223,29 +139,23 @@ uint16_t summarize16(uint32_t word) {
 
 void mixtwo32(uint32_t *state, bytes_t *src, int wordLen) {
     uint32_t mask = wordLen - 1;
+    size_t srcLen = src->len;
     for (int i = 0; i < 8; i++) {
         const struct minimix_src stateMinimixSrc = {
-            .src = {
-                state[i & mask],
-                state[(i + 1) & mask],
-                state[(i + 50) & mask]
-            }
-        };
+            .src = {state[i & mask], state[(i + 1) & mask],
+                    state[(i + 50) & mask]}};
 
         const struct minimix_src srcMinimixSrc = {
-            .src = {
-                src->b[i % src->len],
-                src->b[(i + 2) % src->len],
-                src->b[(i + 27) % src->len]
-            }
-        };
+            .src = {src->b[wrap_idx(i, srcLen)],
+                    src->b[wrap_idx(i + 2, srcLen)],
+                    src->b[wrap_idx(i + 27, srcLen)]}};
 
         minimix32(srcMinimixSrc, &state[(i + 1) & mask]);
 
-        uint32_t curByte =  src->b[i % src->len] |
-                            (src->b[(i + 1) % src->len] << 8) |
-                            (src->b[(i + 2) % src->len] << 16) |
-                            (src->b[(i + 3) % src->len] << 24);
+        uint32_t curByte = src->b[wrap_idx(i, srcLen)] |
+                           (src->b[wrap_idx(i + 1, srcLen)] << 8) |
+                           (src->b[wrap_idx(i + 2, srcLen)] << 16) |
+                           (src->b[wrap_idx(i + 3, srcLen)] << 24);
 
         minimix32(stateMinimixSrc, &curByte);
         uint16_t srcA = curByte & 0xFFFF;

--- a/src-server/shared/utils/mixers/main.c
+++ b/src-server/shared/utils/mixers/main.c
@@ -25,8 +25,7 @@ void arxmix32(uint32_t *state, const int *_r, const int *_i, int wordLen) {
     state[r & (wordLen - 1)] ^= state[r & (wordLen - 1)] >> 16;
 }
 
-void arraymix32(uint32_t *state, const int *index, int wordLen, const int *_i,
-                int miniWordLen) {
+void arraymix32(uint32_t *state, const int *index, int wordLen, const int *_i) {
     int i = *_i;
     uint32_t mask = wordLen - 1;
 
@@ -137,7 +136,7 @@ inline uint16_t summarize16(uint32_t word) {
     return out;
 }
 
-void mixtwo32(uint32_t *state, bytes_t *src, int wordLen) {
+void mixtwo32(uint32_t *state, const bytes_t *src, int wordLen) {
     uint32_t mask = wordLen - 1;
     size_t srcLen = src->len;
     for (int i = 0; i < 8; i++) {

--- a/src-server/shared/utils/mixers/main.h
+++ b/src-server/shared/utils/mixers/main.h
@@ -54,3 +54,4 @@ void smallmix16(uint16_t *word);
 void flavourmix32(uint32_t *word, uint32_t flavour);
 void flavourmix16(uint16_t *word, uint16_t flavour);
 uint16_t summarize16(uint32_t word);
+void mixtwo32(uint32_t *state, bytes_t *src, int wordLen);

--- a/src-server/shared/utils/mixers/main.h
+++ b/src-server/shared/utils/mixers/main.h
@@ -5,8 +5,9 @@
 
 #pragma once
 
-#include <stdint.h>
 #include "src-server/shared/types/main.h"
+#include "src-server/shared/utils/math/main.h"
+#include <stdint.h>
 
 static inline uint32_t fmix32(uint32_t h) {
     h ^= h >> 16;
@@ -38,15 +39,61 @@ static inline uint32_t seed_helper(uint32_t x, uint32_t seed, uint32_t shift) {
     return x & 0xFFFFFFFF;
 }
 
+static inline void arxmix8(uint8_t *word, uint32_t srcWord) {
+    uint8_t msw0 = srcWord & 0xFF;
+    uint8_t msw1 = (srcWord >> 8) & 0xFF;
+    uint8_t msw2 = (srcWord >> 16) & 0xFF;
+    uint8_t msw3 = (srcWord >> 24) & 0xFF;
+
+    uint8_t w = *word;
+    uint8_t old = w;
+
+    w ^= rotl8(msw0, w);
+    w += msw2 ^ rotl8(w, msw0);
+    w ^= msw3 * rotr8(msw1, w + 1);
+
+    w ^= old;
+    *word = w;
+}
+
 struct minimix_src {
     uint32_t src[3];
 };
 
-void minimix32(const struct minimix_src src, uint32_t *pword);
-void minimix16(const struct minimix_src src, uint16_t *pword);
+static inline void minimix32(const struct minimix_src src, uint32_t *pword) {
+    uint32_t curByte = src.src[0];
+    uint32_t word = *pword;
+    word *= 0x39D652DB;
+
+    uint8_t mw0 = word & 0xFF;
+    uint8_t mw1 = (word >> 8) & 0xFF;
+    uint8_t mw2 = (word >> 16) & 0xFF;
+    uint8_t mw3 = (word >> 24) & 0xFF;
+
+    arxmix8(&mw0, src.src[1]);
+    arxmix8(&mw1, src.src[0]);
+    arxmix8(&mw2, src.src[2]);
+    arxmix8(&mw3, word);
+
+    *pword = mw0 | (mw1 << 8) | (mw2 << 16) | (mw3 << 24);
+}
+
+static inline void minimix16(const struct minimix_src src, uint16_t *pword) {
+    uint32_t curByte = src.src[0];
+    uint16_t word = *pword;
+
+    uint8_t mw0 = word & 0xFF;
+    uint8_t mw1 = (word >> 8) & 0xFF;
+
+    arxmix8(&mw0, src.src[1]);
+    arxmix8(&mw1, src.src[0]);
+
+    *pword = mw0 | (uint16_t)(mw1 << 8);
+}
+
 void arxmix32(uint32_t *state, const int *_r, const int *_i, int wordLen);
-void arxmix8(uint8_t *word, uint32_t srcWord);
-void arraymix32(uint32_t *state, const int *index, int wordLen, const int *_i, int miniWordLen);
+void arraymix32(uint32_t *state, const int *index, int wordLen, const int *_i,
+                int miniWordLen);
 void multiarxmix32(uint32_t *state, int wordLen, const int *_i, bytes_t src);
 void dependency32(int wordLen, uint32_t *state, const int *index);
 void smallmix32(uint32_t *word);

--- a/src-server/shared/utils/mixers/main.h
+++ b/src-server/shared/utils/mixers/main.h
@@ -92,8 +92,7 @@ static inline void minimix16(const struct minimix_src src, uint16_t *pword) {
 }
 
 void arxmix32(uint32_t *state, const int *_r, const int *_i, int wordLen);
-void arraymix32(uint32_t *state, const int *index, int wordLen, const int *_i,
-                int miniWordLen);
+void arraymix32(uint32_t *state, const int *index, int wordLen, const int *_i);
 void multiarxmix32(uint32_t *state, int wordLen, const int *_i, bytes_t src);
 void dependency32(int wordLen, uint32_t *state, const int *index);
 void smallmix32(uint32_t *word);
@@ -101,4 +100,4 @@ void smallmix16(uint16_t *word);
 void flavourmix32(uint32_t *word, uint32_t flavour);
 void flavourmix16(uint16_t *word, uint16_t flavour);
 uint16_t summarize16(uint32_t word);
-void mixtwo32(uint32_t *state, bytes_t *src, int wordLen);
+void mixtwo32(uint32_t *state, const bytes_t *src, int wordLen);


### PR DESCRIPTION

To test the speed by yourself, use this `src-server/app/main.c`:

```c

#include "../infra/hash/main.h"
#include "../shared/types/main.h"
#include "../shared/utils/random/main.h"
#include "cli/colors/main.h"
#include "cli/logs/main.h"

#include <stdint.h>
#include <stdlib.h>
#include <string.h>
#include <time.h>

static volatile uint64_t benchmark_sink = 0;

void init() {
  Random.seed(time(NULL));
  Random.seed(Random.rand());
  srand(Random.rand());
}

static void rand_bytes(uchar_t *b, size_t n) {
  for (size_t i = 0; i < n; i++)
    b[i] = rand() & 0xFF;
}

static double elapsed_sec(clock_t s, clock_t e) {
  return (double)(e - s) / CLOCKS_PER_SEC;
}

static void bench_size(size_t size, size_t rounds) {

  uchar_t *buf = malloc(size);
  rand_bytes(buf, size);

  bytes_t src = {.b = buf, .len = size};

  /*
      warmup
  */
  for (size_t i = 0; i < 1000; i++) {
    bytes_t h = Hash.ScorpionX(src);
    benchmark_sink ^= h.b[0];
    free(h.b);
  }

  clock_t s = clock();

  size_t total_bytes = 0;

  for (size_t i = 0; i < rounds; i++) {

    bytes_t h = Hash.ScorpionX(src);

    benchmark_sink ^= h.b[i & 127];

    total_bytes += size;

    free(h.b);
  }

  clock_t e = clock();

  double sec = elapsed_sec(s, e);

  double hashes_per_sec = rounds / sec;
  double mb_per_sec = ((double)total_bytes / (1024.0 * 1024.0)) / sec;

  double ns_per_hash = (sec * 1e9) / rounds;

  Logger.fmt.printf(FG_WHITE_ITALIC "\n[input %zu bytes]\n" RESET, size);

  Logger.fmt.printf("hashes/sec : " BG_PURPLE "%.5f M\n" RESET,
                    hashes_per_sec / 1e6);

  Logger.fmt.printf("throughput : " BG_BLUE "%.5f MB/s\n" RESET, mb_per_sec);

  Logger.fmt.printf("latency    : " BG_GREEN "%.5f ns/hash\n" RESET,
                    ns_per_hash);

  Logger.fmt.printf("cycles/byte (est) : " BG_YELLOW "%.5f\n" RESET,
                    (sec * 3.5e9) / total_bytes);
  /*
      ^ assume 3.5GHz CPU
      better measured with perf
  */

  free(buf);
}

void test_speed() {

  Logger.newLine.println(FG_WHITE_ITALIC "\n[speed benchmark]" RESET);

  bench_size(8, 2000000);
  bench_size(64, 1000000);
  bench_size(256, 400000);
  bench_size(1024, 100000);
  bench_size(4096, 30000);
  bench_size(16384, 8000);
}

int main() {

  init();

  scorpionSettings conf = {
      .hashSize = small, .seed = 0x88C9BCD7, .shiftSeed = 11};

  Hash.settings = &conf;

  test_speed();

  return 0;
}
```

You shall get an output like this:

```
[speed benchmark]

[input 8 bytes]
hashes/sec : 0.748 M
throughput : 5.71 MB/s
latency    : 1336.02 ns/hash
cycles/byte (est) : 584.51

[input 64 bytes]
hashes/sec : 0.402 M
throughput : 24.55 MB/s
latency    : 2485.76 ns/hash
cycles/byte (est) : 135.94

[input 256 bytes]
hashes/sec : 0.152 M
throughput : 37.21 MB/s
latency    : 6560.84 ns/hash
cycles/byte (est) : 89.70

[input 1024 bytes]
hashes/sec : 0.048 M
throughput : 46.39 MB/s
latency    : 21050.97 ns/hash
cycles/byte (est) : 71.95

[input 4096 bytes]
hashes/sec : 0.013 M
throughput : 49.16 MB/s
latency    : 79463.33 ns/hash
cycles/byte (est) : 67.90

[input 16384 bytes]
hashes/sec : 0.003 M
throughput : 50.29 MB/s
latency    : 310673.12 ns/hash
cycles/byte (est) : 66.37
```

---

# Comparing with old algorithm

To be fair, we'll use just the 8 bytes input test with 10k rounds (I wanted to do the test with the 64 bytes source and 2M rounds, but the old algorithm was slow, can't even handle 200k rounds).
The computer used to this test is a low-end laptop, 8gb ram, 2.4GHz. I changed the value in cycles/bytes test to this specs.

### Old Algorithm:

```
[speed benchmark]

[input 8 bytes]
hashes/sec : 0.00058 M
throughput : 0.00445 MB/s
latency    : 1714434.50000 ns/hash
cycles/byte (est) : 514330.35000
```

### New Algorithm:

```
[speed benchmark]

[input 8 bytes]
hashes/sec : 0.73784 M
throughput : 5.62930 MB/s
latency    : 1355.30000 ns/hash
cycles/byte (est) : 406.59000
```